### PR TITLE
Added FINN-related projects

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,6 +17,7 @@ If you would like to contribute to this page by adding a link to an example or d
 | [DNA sequence analysis](https://github.com/davidcastells/KmerFilterAWS) | Zaina Salym, Marc Codina, David Castells-Rufas, UAB  |AWS F1 |
 | [EasyNet](https://github.com/fpgasystems/Vitis_with_100Gbps_TCP-IP) | Zhenhao He *et al.*, ETH Zurich | Alveo U280 |
 | [ERBium](https://github.com/fpgasystems/erbium) | Fabio Maschi *et al.*, ETH Zurich | AWS F1/ Alveo U250/U280 |
+| [FINN Dataflow DNN Accelerator Compiler](https://github.com/Xilinx/finn-examples) | Xilinx Research | Alveo U250/U280 |
 | [Flexible Communication Avoiding Matrix Multiplication on FPGA with HLS](https://github.com/spcl/gemm_hls) | Johannes de Fine Licht, Torsten Hoefler, ETH Zurich | Alveo U250 |
 | [FPGA Accelerated Homomoprhic Computation on AWS](https://github.com/KULeuven-COSIC/HEAT) | Furkan Turan, KU Leuven | AWS F1|
 | [FPGA-based Incremental Delaunay Triangulation Acceleration - parallelized Delaunay Triangulation builder](https://bitbucket.org/necst/xohw2020_fidelta_public) | Alberto Giusti,Saverio Ricci, Marco D. Santambrogio, Politecnico Di Milano | Alveo U200 |
@@ -25,12 +26,10 @@ If you would like to contribute to this page by adding a link to an example or d
 | [N-body simulation](https://bitbucket.org/necst/xohw17_bibbidin-bobbidyboo_public/) | Emanuele Del Sozzo, Marco Rabozzi, Marco Nanni, Prof. Marco Santambrogio, Politecnico Di Milano ||
 | [N-body simulation](https://github.com/spcl/nbody_hls) | Johannes de Fine Licht ETH Zurich | Alveo U250 |
 | [Portable Linear Algebra on FPGA using Data-Centric Parallel Programming](https://github.com/manuelburger/daceBLAS_demo) | Manuel Burger, Johannes de Fine Licht and Torsten Hoefler, ETH Zurich | Alveo U250 |
+| [Single-FPGA and Multi-FPGA ResNet50/MobileNet Accelerators using FINN and InAccel Coral](https://github.com/inaccel/runtime/tree/Xilinx-MP/) | Tobias Alonso, Lucian Petrica, Mario Ruiz, Jakoba Petri-Koenig, Yaman Umuroglu, Ioannis Stamelos, Elias Koromilas, Michaela Blott, Kees Vissers | Alveo U250/U280 |
 | [X-drop on FPGA](https://github.com/albertozeni/XDropXOHW-Public) | Alberto Zeni, Guido Walter Di Donato, Marco D. Santambrogio, Politecnico Di Milano | U280 |
 | [Vitis Network Examples](https://github.com/Xilinx/xup_vitis_network_example) | Mario Ruiz, XUP | Alveo U50/U250/U280 |
 | [5-point motion estimation](https://bitbucket.org/necst/xohw18_5points_public/) | Marco Rabozzi, Emanuele Del Sozzo, Lorenzo Di Tucci, Marco Domenico Santambrogio, Politecnico Di Milano | AWS F1/Alveo U200 |
-| [FINN Dataflow DNN Accelerator Compiler](https://github.com/Xilinx/finn-examples) | Xilinx Research | Alveo U250/U280 |
-| [Single- and Multi-FPGA ResNet50/Mobilenet Accelerators using FINN and InAccel Coral](https://github.com/inaccel/runtime/tree/Xilinx-MP/) | Tobias Alonso, Lucian Petrica, Mario Ruiz, Jakoba Petri-Koenig, Yaman Umuroglu, Ioannis Stamelos, Elias Koromilas, Michaela Blott, Kees Vissers | Alveo U250/U280 |
-
 
 ## PYNQ examples
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -21,13 +21,15 @@ If you would like to contribute to this page by adding a link to an example or d
 | [FPGA Accelerated Homomoprhic Computation on AWS](https://github.com/KULeuven-COSIC/HEAT) | Furkan Turan, KU Leuven | AWS F1|
 | [FPGA-based Incremental Delaunay Triangulation Acceleration - parallelized Delaunay Triangulation builder](https://bitbucket.org/necst/xohw2020_fidelta_public) | Alberto Giusti,Saverio Ricci, Marco D. Santambrogio, Politecnico Di Milano | Alveo U200 |
 | [FPGA implementation of KMP algorithm](https://bitbucket.org/necst/xohw2020_maeve_public) | Sofia Breschi, Beatrice Branchini, Marco D. Santambrogio, Politecnico Di Milano | Alveo U200 |
-| [HPCG Benchmark on FPGA](https://github.com/Xilinx/HPCG_FPGA) | Xilinx | Alveo U280 |
+| [HPCG Benchmark on FPGA](https://github.com/Xilinx/HPCG_FPGA) | Xilinx Research | Alveo U280 |
 | [N-body simulation](https://bitbucket.org/necst/xohw17_bibbidin-bobbidyboo_public/) | Emanuele Del Sozzo, Marco Rabozzi, Marco Nanni, Prof. Marco Santambrogio, Politecnico Di Milano ||
 | [N-body simulation](https://github.com/spcl/nbody_hls) | Johannes de Fine Licht ETH Zurich | Alveo U250 |
 | [Portable Linear Algebra on FPGA using Data-Centric Parallel Programming](https://github.com/manuelburger/daceBLAS_demo) | Manuel Burger, Johannes de Fine Licht and Torsten Hoefler, ETH Zurich | Alveo U250 |
 | [X-drop on FPGA](https://github.com/albertozeni/XDropXOHW-Public) | Alberto Zeni, Guido Walter Di Donato, Marco D. Santambrogio, Politecnico Di Milano | U280 |
 | [Vitis Network Examples](https://github.com/Xilinx/xup_vitis_network_example) | Mario Ruiz, XUP | Alveo U50/U250/U280 |
 | [5-point motion estimation](https://bitbucket.org/necst/xohw18_5points_public/) | Marco Rabozzi, Emanuele Del Sozzo, Lorenzo Di Tucci, Marco Domenico Santambrogio, Politecnico Di Milano | AWS F1/Alveo U200 |
+| [FINN Dataflow DNN Accelerator Compiler](https://github.com/Xilinx/finn-examples) | Xilinx Research | Alveo U250/U280 |
+| [Single- and Multi-FPGA ResNet50/Mobilenet Accelerators using FINN and InAccel Coral](https://github.com/inaccel/runtime/tree/Xilinx-MP/) | Tobias Alonso, Lucian Petrica, Mario Ruiz, Jakoba Petri-Koenig, Yaman Umuroglu, Ioannis Stamelos, Elias Koromilas, Michaela Blott, Kees Vissers | Alveo U250/U280 |
 
 
 ## PYNQ examples


### PR DESCRIPTION
I have added two example repos related to DNN inference with FINN - one is the FINN examples repository which documents the FINN accelerator development process and provides python host code, and the second is a highly-optimized set of FINN accelerators designed for single-FPGA and multi-FPGA DNN acceleration at XACC.