### PR TITLE
Add Fortran-HLS paper to publications list

### DIFF
--- a/docs/publications.md
+++ b/docs/publications.md
@@ -18,6 +18,15 @@ If you would like to contribute to this page by adding a reference to your publi
         <th width="500">Notes</th>
     </tr>
     <tr>
+        <td>Fortran High-Level Synthesis: Reducing the barriers to accelerating HPC codes on FPGAs</td>
+        <td>Gabriel Rodriguez-Canal <em>et al.</em></td>
+        <td><a href="https://arxiv.org/pdf/2308.13274.pdf">Paper</a> <a href="https://gitlab.com/cerl/fortran-hls">GitLab</a></td>
+        <td>The University of Edinburgh</td>
+        <td>In recent years the use of FPGAs to accelerate scientific applications has grown, with numerous applications demonstrating the benefit of FPGAs for high performance workloads. However, whilst High Level Synthesis (HLS) has significantly lowered the barrier to entry in programming FPGAs by enabling programmers to use C++, a major challenge is that most often these codes are not originally written in C++. Instead, Fortran is the lingua franca of scientific computing and-so it requires a complex and time consuming initial step to convert into C++ even before considering the FPGA.
+
+In this paper we describe work enabling Fortran for AMD Xilinx FPGAs by connecting the LLVM Flang front end to AMD Xilinx's LLVM back end. This enables programmers to use Fortran as a first-class language for programming FPGAs, and as we demonstrate enjoy all the tuning and optimisation opportunities that HLS C++ provides. Furthermore, we demonstrate that certain language features of Fortran make it especially beneficial for programming FPGAs compared to C++. The result of this work is a lowering of the barrier to entry in using FPGAs for scientific computing, enabling programmers to leverage their existing codebase and language of choice on the FPGA directly.</td>
+    </tr>
+    <tr>
         <td>High Performance, Low Power Matrix Multiply Design on ACAP: from Architecture, Design Challenges and DSE Perspectives</td>
         <td>Jinming Zhuang <em>et al.</em></td>
         <td>University of Pittsburgh</td>


### PR DESCRIPTION
This work describes how Fortran-HLS enables Fortran in the AMD Xilinx Vitis ecosystem, thus allowing the generation of hardware for FPGAs from a high-level code written in Fortran and its optimisation with HLS constructs. The details of the architecture of the solution, using LLVM Flang are provided. We demonstrate that Fortran-HLS can build and run the 35 kernels of the TeaLeaf mini-app and that the performance achieved is similar to C/C++ HLS's. Furthermore, our tool can also be used to generate hardware from any LLVM-compatible front-end, opening a new research avenue in high-level abstractions for FPGA.