### PR TITLE
[UPDATE] update the new HACC@NUS website link (old link is deprecated)

### DIFF
--- a/docs/nus.md
+++ b/docs/nus.md
@@ -12,7 +12,7 @@ The hardware topology is shown in below.
 <img src="images/nus/xacc_nus.PNG" alt="NUS" class="responsive">
 
 
-For more details and latest update, see the HACC@NUS [website](https://xacchead.d2.comp.nus.edu.sg/)
+For more details and latest update, see the HACC@NUS [website](https://hacc.xtra.science)
 
 ---------------------------------------
 <p class="copyright">Copyright&copy; 2022 Advanced Micro Devices</p>


### PR DESCRIPTION
Hi Mario,

The previous HACC@NUS website is deprecated due to the IP policy from NUS IT, so we update a new link for HACC@NUS website.

Best,
Feng Yu.